### PR TITLE
maintain proxy session

### DIFF
--- a/src/functions/transfer-chat.js
+++ b/src/functions/transfer-chat.js
@@ -1,65 +1,82 @@
-const JWEValidator = require('twilio-flex-token-validator').functionValidator;
+const JWEValidator = require("twilio-flex-token-validator").functionValidator;
 
 exports.handler = JWEValidator(async function(context, event, callback) {
+  // setup twilio client
+  const client = context.getTwilioClient();
 
-    // setup twilio client
-    const client = context.getTwilioClient();
+  // parse data form the incoming http request
+  const originalTaskSid = event.taskSid;
+  const destinationQueueSid = event.destinationQueue;
+  const workerName = event.workerName;
 
-    // parse data form the incoming http request
-    const originalTaskSid = event.taskSid;
-    const destinationQueueSid = event.destinationQueue;
-    const workerName = event.workerName;
+  // setup a response object
+  const response = new Twilio.Response();
+  response.appendHeader("Access-Control-Allow-Origin", "*");
+  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
+  response.appendHeader("Content-Type", "application/json");
+  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
 
-    // setup a response object
-    const response = new Twilio.Response();
-    response.appendHeader('Access-Control-Allow-Origin', '*');
-    response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
-    response.appendHeader('Content-Type', 'application/json');
-    response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
+  // retrieve original task's attributes
+  let originalTask = await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(originalTaskSid)
+    .fetch();
+  let newAttributes = JSON.parse(originalTask.attributes);
 
-    // retrieve original task's attributes
-    let originalTask = await client.taskrouter.workspaces(context.TWILIO_WORKSPACE_SID).tasks(originalTaskSid).fetch();
-    let newAttributes = JSON.parse(originalTask.attributes);
+  // setup new task's attributes such that its linked to the
+  // original task in Twilio WFO
+  if (!newAttributes.hasOwnProperty("conversations")) {
+    newAttributes = Object.assign(newAttributes, {
+      conversations: {
+        conversation_id: originalTaskSid
+      }
+    });
+  }
 
-    // setup new task's attributes such that its linked to the
-    // original task in Twilio WFO
-    if (!newAttributes.hasOwnProperty('conversations')) {
-      newAttributes = Object.assign(newAttributes, {
-          conversations: {
-              conversation_id: originalTaskSid
-          }
-      })
-    }
+  // update task attributes to ignore the agent who transferred the task
+  // its possible that the agent who transferred the task in the queue
+  // the task is being transferred to - but we don't want them to
+  // receive a task they just transferred. It's also possible the agent
+  // is simply transferring to the same queue the task is already in
+  // once again, we don't want the transferring agent to receive the task
+  newAttributes.ignoreAgent = workerName;
 
-    // update task attributes to ignore the agent who transferred the task
-    // its possible that the agent who transferred the task in the queue
-    // the task is being transferred to - but we don't want them to
-    // receive a task they just transferred. It's also possible the agent
-    // is simply transferring to the same queue the task is already in
-    // once again, we don't want the transferring agent to receive the task
-    newAttributes.ignoreAgent = workerName;
+  // update task attributes to put the required queue sid on the task
+  // your workflow would need to be updated to honor these values
+  // and ensure the task makes it to the correct agent/queue
+  newAttributes.requiredQueue = destinationQueueSid;
 
-    // update task attributes to put the required queue sid on the task
-    // your workflow would need to be updated to honor these values
-    // and ensure the task makes it to the correct agent/queue
-    newAttributes.requiredQueue = destinationQueueSid;
-
-    // create New task
-    let newTask = await client.taskrouter.workspaces(context.TWILIO_WORKSPACE_SID).tasks.create({
-        workflowSid: context.TWILIO_WORKFLOW_SID,
-        taskChannel: originalTask.taskChannelUniqueName,
-        attributes: JSON.stringify(newAttributes)
+  // create New task
+  let newTask = await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks.create({
+      workflowSid: context.TWILIO_WORKFLOW_SID,
+      taskChannel: originalTask.taskChannelUniqueName,
+      attributes: JSON.stringify(newAttributes)
     });
 
-    // complete old task
-    let completedTask = await client.taskrouter.workspaces(context.TWILIO_WORKSPACE_SID).tasks(originalTaskSid).update({
-        assignmentStatus: 'completed',
-        reason: 'task transferred'
+  // Set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
+  let updatedAttributes = {
+    ...JSON.parse(originalTask.attributes),
+    channelSid: "CH00000000000000000000000000000000",
+    proxySessionSID: "KC00000000000000000000000000000000"
+  };
+  await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(originalTaskSid)
+    .update({
+      attributes: JSON.stringify(updatedAttributes)
     });
 
-    response.setBody({
-        taskSid: newTask.sid
-    });
+   // Close the original Task
+  await client.taskrouter
+    .workspaces(context.TWILIO_WORKSPACE_SID)
+    .tasks(originalTaskSid)
+    .update({ assignmentStatus: "completed", reason: "task transferred" });
 
-    callback(null, response);
+  response.setBody({
+    taskSid: newTask.sid
+  });
+
+  callback(null, response);
 });

--- a/src/functions/transfer-chat.js
+++ b/src/functions/transfer-chat.js
@@ -1,82 +1,72 @@
-const JWEValidator = require("twilio-flex-token-validator").functionValidator;
+const JWEValidator = require('twilio-flex-token-validator').functionValidator;
 
 exports.handler = JWEValidator(async function(context, event, callback) {
-  // setup twilio client
-  const client = context.getTwilioClient();
 
-  // parse data form the incoming http request
-  const originalTaskSid = event.taskSid;
-  const destinationQueueSid = event.destinationQueue;
-  const workerName = event.workerName;
+    // setup twilio client
+    const client = context.getTwilioClient();
 
-  // setup a response object
-  const response = new Twilio.Response();
-  response.appendHeader("Access-Control-Allow-Origin", "*");
-  response.appendHeader("Access-Control-Allow-Methods", "OPTIONS POST");
-  response.appendHeader("Content-Type", "application/json");
-  response.appendHeader("Access-Control-Allow-Headers", "Content-Type");
+    // parse data form the incoming http request
+    const originalTaskSid = event.taskSid;
+    const destinationQueueSid = event.destinationQueue;
+    const workerName = event.workerName;
 
-  // retrieve original task's attributes
-  let originalTask = await client.taskrouter
-    .workspaces(context.TWILIO_WORKSPACE_SID)
-    .tasks(originalTaskSid)
-    .fetch();
-  let newAttributes = JSON.parse(originalTask.attributes);
+    // setup a response object
+    const response = new Twilio.Response();
+    response.appendHeader('Access-Control-Allow-Origin', '*');
+    response.appendHeader('Access-Control-Allow-Methods', 'OPTIONS POST');
+    response.appendHeader('Content-Type', 'application/json');
+    response.appendHeader('Access-Control-Allow-Headers', 'Content-Type');
 
-  // setup new task's attributes such that its linked to the
-  // original task in Twilio WFO
-  if (!newAttributes.hasOwnProperty("conversations")) {
-    newAttributes = Object.assign(newAttributes, {
-      conversations: {
-        conversation_id: originalTaskSid
-      }
+    // retrieve original task's attributes
+    let originalTask = await client.taskrouter.workspaces(context.TWILIO_WORKSPACE_SID).tasks(originalTaskSid).fetch();
+    let newAttributes = JSON.parse(originalTask.attributes);
+
+    // setup new task's attributes such that its linked to the
+    // original task in Twilio WFO
+    if (!newAttributes.hasOwnProperty('conversations')) {
+      newAttributes = Object.assign(newAttributes, {
+          conversations: {
+              conversation_id: originalTaskSid
+          }
+      })
+    }
+
+    // update task attributes to ignore the agent who transferred the task
+    // its possible that the agent who transferred the task in the queue
+    // the task is being transferred to - but we don't want them to
+    // receive a task they just transferred. It's also possible the agent
+    // is simply transferring to the same queue the task is already in
+    // once again, we don't want the transferring agent to receive the task
+    newAttributes.ignoreAgent = workerName;
+
+    // update task attributes to put the required queue sid on the task
+    // your workflow would need to be updated to honor these values
+    // and ensure the task makes it to the correct agent/queue
+    newAttributes.requiredQueue = destinationQueueSid;
+
+    // Set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
+    let updatedAttributes = {
+      ...JSON.parse(originalTask.attributes),
+      channelSid: "CH00000000000000000000000000000000",
+      proxySessionSID: "KC00000000000000000000000000000000"
+    };
+    await client.taskrouter
+      .workspaces(context.TWILIO_WORKSPACE_SID)
+      .tasks(originalTaskSid)
+      .update({
+        attributes: JSON.stringify(updatedAttributes)
+      });
+
+    // Close the original Task
+    await client.taskrouter
+      .workspaces(context.TWILIO_WORKSPACE_SID)
+      .tasks(originalTaskSid)
+      .update({ assignmentStatus: "completed", reason: "task transferred" });
+
+
+    response.setBody({
+        taskSid: newTask.sid
     });
-  }
 
-  // update task attributes to ignore the agent who transferred the task
-  // its possible that the agent who transferred the task in the queue
-  // the task is being transferred to - but we don't want them to
-  // receive a task they just transferred. It's also possible the agent
-  // is simply transferring to the same queue the task is already in
-  // once again, we don't want the transferring agent to receive the task
-  newAttributes.ignoreAgent = workerName;
-
-  // update task attributes to put the required queue sid on the task
-  // your workflow would need to be updated to honor these values
-  // and ensure the task makes it to the correct agent/queue
-  newAttributes.requiredQueue = destinationQueueSid;
-
-  // create New task
-  let newTask = await client.taskrouter
-    .workspaces(context.TWILIO_WORKSPACE_SID)
-    .tasks.create({
-      workflowSid: context.TWILIO_WORKFLOW_SID,
-      taskChannel: originalTask.taskChannelUniqueName,
-      attributes: JSON.stringify(newAttributes)
-    });
-
-  // Set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
-  let updatedAttributes = {
-    ...JSON.parse(originalTask.attributes),
-    channelSid: "CH00000000000000000000000000000000",
-    proxySessionSID: "KC00000000000000000000000000000000"
-  };
-  await client.taskrouter
-    .workspaces(context.TWILIO_WORKSPACE_SID)
-    .tasks(originalTaskSid)
-    .update({
-      attributes: JSON.stringify(updatedAttributes)
-    });
-
-   // Close the original Task
-  await client.taskrouter
-    .workspaces(context.TWILIO_WORKSPACE_SID)
-    .tasks(originalTaskSid)
-    .update({ assignmentStatus: "completed", reason: "task transferred" });
-
-  response.setBody({
-    taskSid: newTask.sid
-  });
-
-  callback(null, response);
+    callback(null, response);
 });

--- a/src/functions/transfer-chat.js
+++ b/src/functions/transfer-chat.js
@@ -44,6 +44,13 @@ exports.handler = JWEValidator(async function(context, event, callback) {
     // and ensure the task makes it to the correct agent/queue
     newAttributes.requiredQueue = destinationQueueSid;
 
+    // create New task
+    let newTask = await client.taskrouter.workspaces(context.TWILIO_WORKSPACE_SID).tasks.create({
+        workflowSid: context.TWILIO_WORKFLOW_SID,
+        taskChannel: originalTask.taskChannelUniqueName,
+        attributes: JSON.stringify(newAttributes)
+    });
+
     // Set the channelSid and ProxySessionSID to a dummy value. This keeps the session alive
     let updatedAttributes = {
       ...JSON.parse(originalTask.attributes),


### PR DESCRIPTION
Closing the original task is also tearing down the proxy and chat session. This code updates the task with a dummy chat and proxy SID. Then the task is marked complete. This leaves the transferred session active. I am not sure what implications this will have on reporting.